### PR TITLE
feat: upgrade of obsolete members, use of the fresh new headless

### DIFF
--- a/SharpCookieMonster/Program.cs
+++ b/SharpCookieMonster/Program.cs
@@ -164,7 +164,7 @@ namespace SharpCookieMonster
 
             browserProcess.StartInfo.UseShellExecute = false;
             browserProcess.StartInfo.FileName = path;
-            browserProcess.StartInfo.Arguments = $"\"{url}\" --headless --user-data-dir=\"{userdata}\" --remote-debugging-port={port} --remote-allow-origins=ws://localhost:{port}";
+            browserProcess.StartInfo.Arguments = $"\"{url}\" --headless=new --user-data-dir=\"{userdata}\" --remote-debugging-port={port} --remote-allow-origins=ws://localhost:{port}";
             browserProcess.StartInfo.CreateNoWindow = true;
             browserProcess.OutputDataReceived += LogData;
             browserProcess.ErrorDataReceived += LogData;
@@ -204,7 +204,7 @@ namespace SharpCookieMonster
                 }
 
                 var debugUrl = match.Groups[1].Value;
-                const string cookiesRequest = "{\"id\": 1, \"method\": \"Network.getAllCookies\"}";
+                const string cookiesRequest = "{\"id\": 1, \"method\": \"Storage.getCookies\"}";
                 Console.WriteLine("[*] Retrieved debug url: " + debugUrl);
                 return WebSocketRequest35(debugUrl, cookiesRequest);
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/39d72f5c-41b9-4f20-a56b-3e9ab345aba4)

This method was replaced by `Storage.getCookies` this together with `--headless=new` solves the problem of not loading all cookies when running the program in headless mode (the default mode).

![image](https://github.com/user-attachments/assets/99911b7d-58a5-4685-9a23-62d27f00d830)

As seen here, [source](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-getAllCookies)